### PR TITLE
Add GitHub Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: ''
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+- 
+
+## ToDo
+
+- [ ] 
+
+## Goal
+
+- [ ] 
+
+## References
+
+- 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,24 @@
+---
+name: Task Issue
+about: ''
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+- 
+
+## ToDo
+
+- [ ] 
+
+## Goal
+
+- [ ] 
+
+## References
+
+- 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Closes: #
+
+## Description
+
+- 
+
+## Details of this change
+
+- 
+
+## Information for Reviewer
+
+- 


### PR DESCRIPTION
Closes: #9

## Description

- Create GitHub Templates for efficiency.

## Details of this change

- Add GitHub Issue Template.
- Add GitHub Pull Request Template.

## Information for Reviewer

- [Manually creating a single issue template for your repository - GitHub Docs](https://docs.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository)