### PR TITLE
Clear input text

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -37,9 +37,9 @@
       </v-btn>
     </v-app-bar>
 
-    <v-content>
+    <v-main>
       <ChatPage/>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -19,21 +19,21 @@
     </v-row>
     <v-row>
       
-      <template v-if="false">
-        <v-text-field label="Message" v-model="postMessage"/>
-        <v-btn v-on:click="sendMessage">
-          <v-icon>mdi-send</v-icon>
-        </v-btn>
-      </template>
-      <template v-else>
-        <v-text-field label="Message" v-model="postMessage" error/>
-        <v-btn v-on:click="sendMessage">
-          Retry
-        </v-btn>
-        <v-btn v-on:click="sendMessage" color="error">
-          Cancel
-        </v-btn>
-      </template>
+    <template v-if="state === 'idle'">
+      <v-text-field label="Message" v-model="postMessage"/>
+      <v-btn v-on:click="sendMessage">
+        <v-icon>mdi-send</v-icon>
+      </v-btn>
+    </template>
+    <template v-else-if="state === 'sendError'">
+      <v-text-field label="Message" v-model="postMessage" error/>
+      <v-btn v-on:click="sendMessage">
+        Retry
+      </v-btn>
+      <v-btn v-on:click="sendMessage" color="error">
+        Cancel
+      </v-btn>
+    </template>
     </v-row>
   </v-container>
 </template>
@@ -45,7 +45,8 @@
     data: () => ({
       messages: [],
       postMessage: "",
-      socket: null
+      socket: null,
+      state: "idle"
     }),
     methods: {
       sendMessage() {
@@ -55,18 +56,22 @@
         switch ( readyState ) {
           case 0:
             console.log('Socket has been created. Please waiting for a moment.');
+            this.state = "sendError";
             break;
           case 1:
             console.log('The connection is ready!!');
             console.log(this.postMessage);
             this.socket.send(this.postMessage);
             this.clearMessage();
+            this.state = "idle";
             break;
           case 2:
             console.log('WebSocket is already in CLOSING state.');
+            this.state = "sendError";
             break;
           case 3:
             console.log('WebSocket is already in CLOSED state.');
+            this.state = "sendError";
             break;
         }
       },

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -20,7 +20,7 @@
     <v-row>
       <v-text-field label="Message" v-model="postMessage"/>
       <v-btn v-on:click="sendMessage">
-        <v-icon>mdi-pencil</v-icon>
+        <v-icon>mdi-send</v-icon>
       </v-btn>
     </v-row>
   </v-container>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -64,7 +64,7 @@
         const readyState = this.socket.readyState;
         console.log(`readyState value is: ${readyState}`);
 
-        switch ( readyState ) {
+        switch (readyState) {
           case 0:
             console.log('Socket has been created. Please waiting for a moment.');
             this.state = "sendError";

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -39,22 +39,25 @@
       sendMessage() {
         console.log(this.postMessage);
         this.socket.send(this.postMessage);
-	this.clearMessage();
+        this.clearMessage();
       },
       clearMessage() {
         this.postMessage = '';
       },
       receiveMessage(event) {
-	console.log('Message from server ', event.data);
-	this.messages.push({
+        console.log('Message from server ', event.data);
+        this.messages.push({
           title: "Example",
           value: event.data
-	});
+        });
       }
     },
     created: function() {
       this.socket = new WebSocket('ws://localhost:8081/broker');
       this.socket.onmessage = this.receiveMessage;
+    },
+    beforeDestroy: function() {
+      this.socket.close();
     }
   }
 </script>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -39,6 +39,10 @@
       sendMessage() {
         console.log(this.postMessage);
         this.socket.send(this.postMessage);
+	this.clearMessage();
+      },
+      clearMessage() {
+        this.postMessage = '';
       },
       receiveMessage(event) {
 	console.log('Message from server ', event.data);

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -30,7 +30,7 @@
       <v-btn v-on:click="sendMessage">
         Retry
       </v-btn>
-      <v-btn v-on:click="sendMessage" color="error">
+      <v-btn v-on:click="clearMessage" color="error">
         Cancel
       </v-btn>
     </template>
@@ -77,6 +77,7 @@
       },
       clearMessage() {
         this.postMessage = '';
+        this.state = "idle"
       },
       receiveMessage(event) {
         console.log('Message from server ', event.data);

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -37,9 +37,26 @@
     }),
     methods: {
       sendMessage() {
-        console.log(this.postMessage);
-        this.socket.send(this.postMessage);
-        this.clearMessage();
+        const readyState = this.socket.readyState;
+        console.log(`readyState value is: ${readyState}`);
+
+        switch ( readyState ) {
+          case 0:
+            console.log('Socket has been created. Please waiting for a moment.');
+            break;
+          case 1:
+            console.log('The connection is ready!!');
+            console.log(this.postMessage);
+            this.socket.send(this.postMessage);
+            this.clearMessage();
+            break;
+          case 2:
+            console.log('WebSocket is already in CLOSING state.');
+            break;
+          case 3:
+            console.log('WebSocket is already in CLOSED state.');
+            break;
+        }
       },
       clearMessage() {
         this.postMessage = '';

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -18,10 +18,22 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-text-field label="Message" v-model="postMessage"/>
-      <v-btn v-on:click="sendMessage">
-        <v-icon>mdi-send</v-icon>
-      </v-btn>
+      
+      <template v-if="false">
+        <v-text-field label="Message" v-model="postMessage"/>
+        <v-btn v-on:click="sendMessage">
+          <v-icon>mdi-send</v-icon>
+        </v-btn>
+      </template>
+      <template v-else>
+        <v-text-field label="Message" v-model="postMessage" error/>
+        <v-btn v-on:click="sendMessage">
+          Retry
+        </v-btn>
+        <v-btn v-on:click="sendMessage" color="error">
+          Cancel
+        </v-btn>
+      </template>
     </v-row>
   </v-container>
 </template>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -49,6 +49,10 @@
       state: "idle"
     }),
     methods: {
+      openWebSocket() {
+        this.socket = new WebSocket('ws://localhost:8081/broker');
+        this.socket.onmessage = this.receiveMessage;
+      },
       sendMessage() {
         const readyState = this.socket.readyState;
         console.log(`readyState value is: ${readyState}`);
@@ -88,8 +92,7 @@
       }
     },
     created: function() {
-      this.socket = new WebSocket('ws://localhost:8081/broker');
-      this.socket.onmessage = this.receiveMessage;
+      this.openWebSocket();
     },
     beforeDestroy: function() {
       this.socket.close();


### PR DESCRIPTION
Closes: #19

## Description

- Clear input text

## Details of this change

- Implement `clearMessage()`
- `v-content` to `v-main`
- Change `v-icon` from `mdi-pencil` to [`mdi-send`](https://cdn.materialdesignicons.com/1.1.34/)

## Information for Reviewer

- Fixed the `App.vue` because the following deprecated errors were appearing.

```
[Vuetify] [UPGRADE] 'v-content' is deprecated, use 'v-main' instead.
```