### PR TITLE
Fix MessageBroker

### DIFF
--- a/message_broker/main.go
+++ b/message_broker/main.go
@@ -17,7 +17,7 @@ func main() {
 	broker := broker.NewChatMessageBroker(hub)
 	router.HandleFunc("/room", broker.CreateRoom).Methods("POST")
 	router.HandleFunc("/room/{id}", broker.DeleteRoom).Methods("DELETE")
-	router.HandleFunc("/broker", broker.PostMessage).Methods("POST")
+	router.HandleFunc("/broker", broker.PostMessage).Methods("GET")
 	log.Fatal(http.ListenAndServe(":8081", router))
 
 	fmt.Println("Done")


### PR DESCRIPTION
Closes: #33

## Description

Fixed a problem that could not be communicate from client to MessageBroker. 

## Details of this change

Change allowed HTTP Method from POST to GET.

## Information for Reviewer

It was confirmed to work properly with Docker Compose.

![worked](https://user-images.githubusercontent.com/4405012/90513078-1878bb00-e19a-11ea-97d4-7c637934e4a2.png)



